### PR TITLE
Fix incorrect postgres DSN string

### DIFF
--- a/internal/interfaces/repository/db.go
+++ b/internal/interfaces/repository/db.go
@@ -7,7 +7,7 @@ import (
 
 func NewDBConnection(host, port, user, pass, dbName string) (*sql.DB, error) {
 	dsn := fmt.Sprintf(
-		"host=%s port=%s user=%s pass=%s dbName=%s sslmode=disable",
+		"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
 		host, port, user, pass, dbName,
 	)
 	db, err := sql.Open("postgres", dsn)


### PR DESCRIPTION
## Summary
- use correct `password` and `dbname` parameters in `NewDBConnection`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840e1200c0883229aab1a9e67a0d101